### PR TITLE
Named Github Tokens

### DIFF
--- a/features/login.feature
+++ b/features/login.feature
@@ -1,4 +1,4 @@
-Feature: Login to Runnable
+Feature: Login into Runnable
   Background:
     Given I am part of the "Runnable" organization
     And I am part of the "Runnabear" organization
@@ -24,6 +24,7 @@ Feature: Login to Runnable
       """
     And the exit status should be 0
     And I should be using the "Runnabear" organization
+    And there should be a token generated for "bkendall"
 
   Scenario: Login to Runnable using two-factor authentication
     Given I require a two-factor code "123456"
@@ -41,3 +42,4 @@ Feature: Login to Runnable
     And the output should contain "Choose a GitHub organization"
     And the exit status should be 0
     And I should be using the "Runnable" organization
+    And there should be a token generated for "bkendall"

--- a/features/steps.js
+++ b/features/steps.js
@@ -191,20 +191,20 @@ module.exports = function () {
     var flushed = this.childProcess.stdin.write(input + '\r\n')
     debug('stdin flushed?', flushed)
     if (flushed) {
-      return Promise.resolve().delay(process.env._STEP_DELAY_MS || 500)
+      return Promise.resolve().delay(process.env._STEP_DELAY_MS || 1000)
     } else {
       return new Promise(function (resolve) {
         this.childProcess.stdin.on('drain', resolve)
-      }.bind(this)).delay(process.env._STEP_DELAY_MS || 500)
+      }.bind(this)).delay(process.env._STEP_DELAY_MS || 1000)
     }
   })
 
   function runCommand (ctx, command) {
-    var env = assign({}, process.env, environment)
+    var env = assign({}, process.env, ctx.environment)
     var args = command.split(/\s+/)
     command = args.shift()
-    // console.log('running:', command, args)
-    // console.log('in cwd:', ctx._fs.cwd)
+    debug('running:', command, args)
+    debug('in cwd:', ctx._fs.cwd)
     return execFile(command, args, { env: env, cwd: ctx._fs.cwd })
   }
 

--- a/lib/login.js
+++ b/lib/login.js
@@ -5,6 +5,7 @@ var read = Promise.promisify(require('read'))
 var request = require('request')
 var url = require('url')
 var pluck = require('101/pluck')
+var os = require('os')
 
 var Login = module.exports = {
   _read: read,
@@ -69,7 +70,7 @@ var Login = module.exports = {
       },
       json: {
         scopes: [ 'repo', 'user:email' ],
-        note: 'Runnable CLI'
+        note: 'Runnable CLI for ' + os.hostname()
       }
     }
     if (token) {

--- a/test/unit/login.js
+++ b/test/unit/login.js
@@ -1,8 +1,9 @@
 'use strict'
 
 var chai = require('chai')
-var sinon = require('sinon')
+var os = require('os')
 var request = require('request')
+var sinon = require('sinon')
 
 require('sinon-as-promised')(require('bluebird'))
 chai.use(require('chai-as-promised'))
@@ -262,7 +263,7 @@ describe('Login', function () {
               },
               json: {
                 scopes: [ 'repo', 'user:email' ],
-                note: 'Runnable CLI'
+                note: 'Runnable CLI for ' + os.hostname()
               }
             },
             sinon.match.func


### PR DESCRIPTION
We need a change in here to allow tokens to be named for environments for which they are created. This is accomplished here by adding the hostname to the token's note.

Additionally, more assertions in the feature have been added to assert that the token was successfully created.

In order to make the tests more stable, the environment information was moved to the hooks and the post-input delay was increased to a second by default.
