### PR TITLE
Test on Node 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
 - '0.10'
-- '4.2'
+- '4'
 sudo: false
 cache:
   directories:


### PR DESCRIPTION
`4.x.x` is the latest LTS, so we can just test against `4` not just `4.2`
