### PR TITLE
Fix Build Log Output

### DIFF
--- a/lib/logs.js
+++ b/lib/logs.js
@@ -30,15 +30,16 @@ var Logs = module.exports = {
 
     logStream.on('end', function () { socket.end() })
 
+    var printTypes = [ 'log', 'docker' ]
     logStream.on('data', function (data) {
       if (Array.isArray(data)) {
         data.forEach(function (d) {
-          if (d.type && d.type === 'log') {
+          if (printTypes.indexOf(d.type) !== -1) {
             process.stdout.write(d.content)
           }
         })
       } else {
-        if (data.type === 'log') {
+        if (printTypes.indexOf(data.type) !== -1) {
           process.stdout.write(data.content)
         }
       }

--- a/test/unit/logs.js
+++ b/test/unit/logs.js
@@ -249,6 +249,15 @@ describe('Logs Methods', function () {
           })
       })
 
+      it('should write docker logs', function () {
+        return assert.isFulfilled(Logs._connectToContainerBuildLogs(mockArgs, mockInstance))
+          .then(function () {
+            mockSubstream.emit('data', { type: 'docker', content: 'Step' })
+            sinon.assert.calledOnce(process.stdout.write)
+            sinon.assert.calledWithExactly(process.stdout.write, 'Step')
+          })
+      })
+
       it('should not write basic logs that are not logs', function () {
         return assert.isFulfilled(Logs._connectToContainerBuildLogs(mockArgs, mockInstance))
           .then(function () {


### PR DESCRIPTION
Docker build log content was being ignored. This fixes that issue and now prints all the expected logs.
