### PR TITLE
Validate Org Input and Accept Names

### DIFF
--- a/features/login.feature
+++ b/features/login.feature
@@ -22,6 +22,7 @@ Feature: Login into Runnable
 
       >
       """
+    And the output should contain "Selected organization:"
     And the exit status should be 0
     And I should be using the "Runnabear" organization
     And there should be a token generated for "bkendall"
@@ -40,6 +41,7 @@ Feature: Login into Runnable
     And the output should contain "Two-factor code:"
     And the output should contain "Authenticated"
     And the output should contain "Choose a GitHub organization"
+    And the output should contain "Selected organization:"
     And the exit status should be 0
     And I should be using the "Runnable" organization
     And there should be a token generated for "bkendall"

--- a/features/org.feature
+++ b/features/org.feature
@@ -4,7 +4,7 @@ Feature: Organization Selection
     And I am part of the "Runnabear" organization
     And I am using the "Runnable" organization
 
-  Scenario: Change Organization
+  Scenario: Change Organization by Number
     When I run `runnable org` interactively
     And I type "1"
     And I finished my input
@@ -16,6 +16,30 @@ Feature: Organization Selection
         2) Runnable
 
       >
+      """
+    And the output should contain:
+      """
+      Selected organization: Runnabear
+      """
+    And the exit status should be 0
+    And I should be using the "Runnabear" organization
+
+  Scenario: Change Organization by Name
+    When I run `runnable org` interactively
+    And I type "Runnabear"
+    And I finished my input
+    Then the output should contain:
+      """
+      Choose a GitHub organization to use with Runnable [1-2]
+
+        1) Runnabear
+        2) Runnable
+
+      >
+      """
+    And the output should contain:
+      """
+      Selected organization: Runnabear
       """
     And the exit status should be 0
     And I should be using the "Runnabear" organization

--- a/features/org.feature
+++ b/features/org.feature
@@ -43,3 +43,10 @@ Feature: Organization Selection
       """
     And the exit status should be 0
     And I should be using the "Runnabear" organization
+
+  Scenario: Choosing an Invalid Organization
+    When I run `runnable org` interactively
+    And I type "foobar"
+    And I finished my input
+    Then the output should contain "Could not parse your selection"
+    And I should be using the "Runnable" organization

--- a/lib/login.js
+++ b/lib/login.js
@@ -1,6 +1,8 @@
 'use strict'
 
+require('colors')
 var Promise = require('bluebird')
+var isNumber = require('101/is-number')
 var read = Promise.promisify(require('read'))
 var request = require('request')
 var url = require('url')
@@ -88,7 +90,7 @@ var Login = module.exports = {
       .then(function (orgsData) {
         return orgsData.map(pluck('login')).sort()
       })
-      .then(function (orgs) {
+      .then(function promptForOrg (orgs) {
         var orgList = orgs.map(function (o, i) {
           return '  ' + (i + 1) + ') ' + o
         })
@@ -105,9 +107,26 @@ var Login = module.exports = {
         })
           .then(function (selection) {
             var index = parseInt(selection) - 1
+            if (!isNumber(index)) {
+              index = orgs.map(function (o) { return o.toLowerCase() })
+                .indexOf(selection.toString().toLowerCase())
+            }
             var org = orgs[index]
-            return org
+            if (!org) {
+              Login._output([
+                '',
+                'Could not parse your selection. Try again?'.bold.red,
+                ''
+              ].join('\n'))
+              return promptForOrg(orgs)
+            } else {
+              return org
+            }
           })
+      })
+      .then(function (org) {
+        Login._output('Selected organization:'.green, org)
+        return org
       })
   })
 }

--- a/test/unit/login.js
+++ b/test/unit/login.js
@@ -319,10 +319,12 @@ describe('Login', function () {
       }
       mockArgs = { _user: mockUser }
       sinon.stub(Login, '_read').resolves('1')
+      sinon.stub(Login, '_output')
     })
 
     afterEach(function () {
       Login._read.restore()
+      Login._output.restore()
     })
 
     describe('errors', function () {
@@ -363,6 +365,36 @@ describe('Login', function () {
           sinon.assert.calledWithExactly(
             Login._read,
             { prompt: sinon.match.string }
+          )
+        })
+    })
+
+    it('should pick an org by name', function () {
+      Login._read.resolves('foo')
+      return assert.isFulfilled(Login.chooseOrg(mockArgs))
+        .then(function (org) {
+          assert.equal(org, 'foo')
+        })
+    })
+
+    it('should prompt twice if the first input was bad', function () {
+      Login._read.onFirstCall().resolves('baz')
+      Login._read.onSecondCall().resolves('2')
+      return assert.isFulfilled(Login.chooseOrg(mockArgs))
+        .then(function (org) {
+          assert.equal(org, 'foo')
+          sinon.assert.calledTwice(Login._read)
+        })
+    })
+
+    it('should print the selected org', function () {
+      return assert.isFulfilled(Login.chooseOrg(mockArgs))
+        .then(function () {
+          sinon.assert.calledOnce(Login._output)
+          sinon.assert.calledWithExactly(
+            Login._output,
+            sinon.match(/selected organization/i),
+            'bar'
           )
         })
     })


### PR DESCRIPTION
For the org selector, we can now accept names as well as numbers. There is also now retry built in so we will immediately ask the user again!
- [x] @thejsj
